### PR TITLE
Improve login analytics

### DIFF
--- a/Analytics.swift
+++ b/Analytics.swift
@@ -51,6 +51,8 @@ struct Analytics {
         
         // actions
         case connectStrava
+        case receivedValidStravaOauthRedirect
+        case receivedInvalidStravaOauthRedirect
         case addWidgetHelp
         case refreshActivities
         case shareFeedback
@@ -76,5 +78,7 @@ struct Analytics {
         //action attributes
         case from
         case abTestGroup
+        case cause
+        case with
     }
 }

--- a/Memories.xcodeproj/xcshareddata/xcschemes/MemoriesWidgetExtension.xcscheme
+++ b/Memories.xcodeproj/xcshareddata/xcschemes/MemoriesWidgetExtension.xcscheme
@@ -100,7 +100,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
-      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Memories/StravaLoginView.swift
+++ b/Memories/StravaLoginView.swift
@@ -41,13 +41,13 @@ struct StravaLoginView: View {
             VStack(spacing: 12.0) {
              
                 Button {
-                    Analytics.capture(event: .connectStrava)
-                    
                     // Open Strava app if installed, if will be redirected to our app through a deeplink
                     // UIApplication can only be used in a UIKit context
                     if UIApplication.shared.canOpenURL(self.loginViewModel.getStravaMobileUrl()) {
+                        Analytics.capture(event: .connectStrava, eventProperties: [.with: "stravaApp"])
                         UIApplication.shared.open(self.loginViewModel.getStravaMobileUrl(), options: [:])
                     } else {
+                        Analytics.capture(event: .connectStrava, eventProperties: [.with: "stravaWebview"])
                         self.loginViewModel.startWebOauth()
                     }
                 } label: {


### PR DESCRIPTION
* New event: `receivedValidStravaOauthRedirect`
* New event: `receivedInvalidStravaOauthRedirect`
  * Property `cause`: "invalid scope" or "invalid url"
* Added a property to `connectStrava` event: `with`: "stravaApp" or "stravaWebview"

Idea is to create a new funnel:

1. connectStrava
2. receivedValidStravaOauthRedirect
3. Identify

-> If drop between 1 and 2 -> users don't bother login with Strava or restrict the scope
-> If drop between 2 and 3 -> bug or backend waiting time