### PR TITLE
Fix refresh on widget open when widget on macOS Sonoma

### DIFF
--- a/Memories.xcodeproj/project.pbxproj
+++ b/Memories.xcodeproj/project.pbxproj
@@ -23,6 +23,14 @@
 		2D7C61DE2A1D5CCF0050AAB0 /* Athlete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7C61DC2A1D59040050AAB0 /* Athlete.swift */; };
 		2D7C61DF2A1D5D100050AAB0 /* StravaLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE590BC2A053D9C0041EA4D /* StravaLoginViewModel.swift */; };
 		2D7C61E12A1D5D3B0050AAB0 /* DateFormatter+standard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7C61E02A1D5D3B0050AAB0 /* DateFormatter+standard.swift */; };
+		2D7EFD482B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD472B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift */; };
+		2D7EFD492B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD472B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift */; };
+		2D7EFD4B2B0385D900B3D624 /* SimpleEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD4A2B0385D900B3D624 /* SimpleEntry.swift */; };
+		2D7EFD4C2B0385D900B3D624 /* SimpleEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD4A2B0385D900B3D624 /* SimpleEntry.swift */; };
+		2D7EFD4E2B03862000B3D624 /* TimelineCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */; };
+		2D7EFD4F2B03862000B3D624 /* TimelineCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */; };
+		2D7EFD512B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */; };
+		2D7EFD522B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */; };
 		2D7F7A7F2A6AAAAB00C30723 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 2D7F7A7E2A6AAAAB00C30723 /* PostHog */; };
 		2DCAC7A42A208FE7007A11F9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCAC7A32A208FE7007A11F9 /* Config.swift */; };
 		2DCAC7A52A208FE7007A11F9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCAC7A32A208FE7007A11F9 /* Config.swift */; };
@@ -111,6 +119,10 @@
 		2D5EAEE32A1D51B400FB9C33 /* ActivityViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewModel.swift; sourceTree = "<group>"; };
 		2D7C61DC2A1D59040050AAB0 /* Athlete.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Athlete.swift; sourceTree = "<group>"; };
 		2D7C61E02A1D5D3B0050AAB0 /* DateFormatter+standard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+standard.swift"; sourceTree = "<group>"; };
+		2D7EFD472B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoriesWidgetConfigurationIntent.swift; sourceTree = "<group>"; };
+		2D7EFD4A2B0385D900B3D624 /* SimpleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleEntry.swift; sourceTree = "<group>"; };
+		2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineCommon.swift; sourceTree = "<group>"; };
+		2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicTimelineProvider.swift; sourceTree = "<group>"; };
 		2DCAC7A12A208D93007A11F9 /* dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = dev.xcconfig; sourceTree = "<group>"; };
 		2DCAC7A22A208DA2007A11F9 /* prod.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = prod.xcconfig; sourceTree = "<group>"; };
 		2DCAC7A32A208FE7007A11F9 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -288,6 +300,10 @@
 				E4604FC22A05C6D100D838DF /* MemoriesWidgetView.swift */,
 				E48E098A2A05BF99002456E5 /* Assets.xcassets */,
 				E48E098C2A05BF99002456E5 /* Info.plist */,
+				2D7EFD472B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift */,
+				2D7EFD4A2B0385D900B3D624 /* SimpleEntry.swift */,
+				2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */,
+				2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */,
 			);
 			path = MemoriesWidget;
 			sourceTree = "<group>";
@@ -457,9 +473,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				E4604FC12A05C55100D838DF /* MemoriesWidget.swift in Sources */,
+				2D7EFD512B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */,
+				2D7EFD482B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift in Sources */,
 				E468D3FD2A0663E50017070A /* Analytics.swift in Sources */,
+				2D7EFD4E2B03862000B3D624 /* TimelineCommon.swift in Sources */,
 				2DCAC7A42A208FE7007A11F9 /* Config.swift in Sources */,
 				2DE590BF2A053D9C0041EA4D /* StravaLoginView.swift in Sources */,
+				2D7EFD4B2B0385D900B3D624 /* SimpleEntry.swift in Sources */,
 				E4604FC42A05C98800D838DF /* MemoriesWidgetView.swift in Sources */,
 				E48E099B2A05C2E6002456E5 /* MemoriesApp.swift in Sources */,
 				E46FD4B52A0EA308000396EA /* WebView.swift in Sources */,
@@ -491,7 +511,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D7EFD4C2B0385D900B3D624 /* SimpleEntry.swift in Sources */,
+				2D7EFD492B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift in Sources */,
+				2D7EFD522B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */,
 				E4604FC32A05C6D100D838DF /* MemoriesWidgetView.swift in Sources */,
+				2D7EFD4F2B03862000B3D624 /* TimelineCommon.swift in Sources */,
 				E48E09892A05BF98002456E5 /* MemoriesWidget.swift in Sources */,
 				E4A397112A616485009A2E6F /* Analytics.swift in Sources */,
 				2DCAC7A52A208FE7007A11F9 /* Config.swift in Sources */,
@@ -668,10 +692,12 @@
 				INFOPLIST_FILE = Memories/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Memories;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Send photos to support chat";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -703,10 +729,12 @@
 				INFOPLIST_FILE = Memories/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Memories;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Send photos to support chat";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Memories.xcodeproj/project.pbxproj
+++ b/Memories.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		2D7EFD4F2B03862000B3D624 /* TimelineCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */; };
 		2D7EFD512B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */; };
 		2D7EFD522B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */; };
+		2D7EFD542B03E10700B3D624 /* ConfigurableMemoriesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD532B03E10700B3D624 /* ConfigurableMemoriesWidget.swift */; };
+		2D7EFD552B03E10700B3D624 /* ConfigurableMemoriesWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D7EFD532B03E10700B3D624 /* ConfigurableMemoriesWidget.swift */; };
 		2D7F7A7F2A6AAAAB00C30723 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 2D7F7A7E2A6AAAAB00C30723 /* PostHog */; };
 		2DCAC7A42A208FE7007A11F9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCAC7A32A208FE7007A11F9 /* Config.swift */; };
 		2DCAC7A52A208FE7007A11F9 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DCAC7A32A208FE7007A11F9 /* Config.swift */; };
@@ -123,6 +125,7 @@
 		2D7EFD4A2B0385D900B3D624 /* SimpleEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleEntry.swift; sourceTree = "<group>"; };
 		2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineCommon.swift; sourceTree = "<group>"; };
 		2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassicTimelineProvider.swift; sourceTree = "<group>"; };
+		2D7EFD532B03E10700B3D624 /* ConfigurableMemoriesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableMemoriesWidget.swift; sourceTree = "<group>"; };
 		2DCAC7A12A208D93007A11F9 /* dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = dev.xcconfig; sourceTree = "<group>"; };
 		2DCAC7A22A208DA2007A11F9 /* prod.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = prod.xcconfig; sourceTree = "<group>"; };
 		2DCAC7A32A208FE7007A11F9 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
@@ -304,6 +307,7 @@
 				2D7EFD4A2B0385D900B3D624 /* SimpleEntry.swift */,
 				2D7EFD4D2B03862000B3D624 /* TimelineCommon.swift */,
 				2D7EFD502B0386C200B3D624 /* ClassicTimelineProvider.swift */,
+				2D7EFD532B03E10700B3D624 /* ConfigurableMemoriesWidget.swift */,
 			);
 			path = MemoriesWidget;
 			sourceTree = "<group>";
@@ -474,6 +478,7 @@
 			files = (
 				E4604FC12A05C55100D838DF /* MemoriesWidget.swift in Sources */,
 				2D7EFD512B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */,
+				2D7EFD542B03E10700B3D624 /* ConfigurableMemoriesWidget.swift in Sources */,
 				2D7EFD482B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift in Sources */,
 				E468D3FD2A0663E50017070A /* Analytics.swift in Sources */,
 				2D7EFD4E2B03862000B3D624 /* TimelineCommon.swift in Sources */,
@@ -511,6 +516,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2D7EFD552B03E10700B3D624 /* ConfigurableMemoriesWidget.swift in Sources */,
 				2D7EFD4C2B0385D900B3D624 /* SimpleEntry.swift in Sources */,
 				2D7EFD492B037F2800B3D624 /* MemoriesWidgetConfigurationIntent.swift in Sources */,
 				2D7EFD522B0386C200B3D624 /* ClassicTimelineProvider.swift in Sources */,

--- a/Memories/Info.plist
+++ b/Memories/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIUserInterfaceStyle</key>
-	<string>Light</string>
 	<key>AMPLITUDE_API_KEY</key>
 	<string>$(AMPLITUDE_API_KEY)</string>
 	<key>APP_GROUP_NAME</key>
@@ -31,9 +29,11 @@
 	<array>
 		<string>strava</string>
 	</array>
+	<key>NSUserActivityTypes</key>
+	<array>
+		<string>WidgetConfigurationIntent</string>
+	</array>
 	<key>POSTHOG_API_KEY</key>
 	<string>$(POSTHOG_API_KEY)</string>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>Send photos to support chat</string>
 </dict>
 </plist>

--- a/Memories/MemoriesHomeView.swift
+++ b/Memories/MemoriesHomeView.swift
@@ -351,7 +351,7 @@ struct MemoriesHomeView: View {
     func forceRefreshActivity() async {
         Analytics.capture(event: .refreshActivities)
         
-        await activityViewModel.fetchAndStoreRandomActivity()
+        await activityViewModel.fetchRandomActivity()
         activityViewModel.forceRefreshWidget()
         self.triggerConfettis()
     }

--- a/MemoriesWidget/ClassicTimelineProvider.swift
+++ b/MemoriesWidget/ClassicTimelineProvider.swift
@@ -36,7 +36,7 @@ struct ClassicTimelineProvider: TimelineProvider {
             completion(self.common.buildTimeline(activity: activity, error: error))
         } else {
             Task {
-                await viewModel.fetchAndStoreRandomActivity()
+                await viewModel.fetchRandomActivity()
                 completion(self.common.buildTimeline(activity: viewModel.activity, error: viewModel.error))
             }
         }

--- a/MemoriesWidget/ClassicTimelineProvider.swift
+++ b/MemoriesWidget/ClassicTimelineProvider.swift
@@ -1,0 +1,44 @@
+//
+//  ClassicTimelineProvider.swift
+//  Memories
+//
+//  Created by Paul Nicolet on 14/11/2023.
+//
+
+import Foundation
+import WidgetKit
+import SwiftUI
+import Activity
+
+struct ClassicTimelineProvider: TimelineProvider {
+    private let common = TimelineCommon()
+    private let viewModel = ActivityViewModel()
+    
+    func placeholder(in context: Context) -> SimpleEntry {
+        return SimpleEntry(date: Date())
+    }
+
+    @MainActor func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
+        let activity = ActivityViewModel.getActivityFromUserDefault()
+        let error = ActivityViewModel.getErrorFromUserDefault()
+        completion(SimpleEntry(date: Date(), activity: activity, error: error))
+    }
+
+    @MainActor func getTimeline(in context: Context, completion: @escaping (Timeline<SimpleEntry>) -> ()) {
+        self.common.initializeDependencies()
+        self.common.onGetTimeline()
+        
+        // Home screen was forced refresh, update the widget with user defaults only
+        if ActivityViewModel.getUnseenWidgetForceRefreshFromUserDefault() {
+            let activity = ActivityViewModel.getActivityFromUserDefault()
+            let error = ActivityViewModel.getErrorFromUserDefault()
+            viewModel.forceRefreshWidgetProcessed()
+            completion(self.common.buildTimeline(activity: activity, error: error))
+        } else {
+            Task {
+                await viewModel.fetchAndStoreRandomActivity()
+                completion(self.common.buildTimeline(activity: viewModel.activity, error: viewModel.error))
+            }
+        }
+    }
+}

--- a/MemoriesWidget/ConfigurableMemoriesWidget.swift
+++ b/MemoriesWidget/ConfigurableMemoriesWidget.swift
@@ -1,0 +1,30 @@
+//
+//  MemoriesWidget.swift
+//  MemoriesWidget
+//
+//  Created by Vincent Ballet on 06/05/2023.
+//
+
+import WidgetKit
+import SwiftUI
+
+@available(iOS 17.0, *)
+struct ConfigurableMemoriesWidget: Widget {
+    let kind: String = "ConfigurableMemoriesWidget"
+    
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: MemoriesWidgetConfigurationIntent.self, provider: ConfigurationTimelineProvider()) { entry in
+            MemoriesWidgetEntryView(entry: entry)
+        }
+        .contentMarginsDisabled()
+        .configurationDisplayName("MyText Widget")
+        .description("Show you favorite text!")
+    }
+}
+
+struct ConfigurableMemoriesWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        MemoriesWidgetEntryView(entry: SimpleEntry(date: Date()))
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+    }
+}

--- a/MemoriesWidget/MemoriesWidget.swift
+++ b/MemoriesWidget/MemoriesWidget.swift
@@ -7,93 +7,12 @@
 
 import WidgetKit
 import SwiftUI
-import Activity
-import PostHog
-import Sentry
-
-struct Provider: TimelineProvider {
-    private let viewModel = ActivityViewModel()
-    
-    func placeholder(in context: Context) -> SimpleEntry {
-        return SimpleEntry(date: Date())
-    }
-
-    @MainActor func getSnapshot(in context: Context, completion: @escaping (SimpleEntry) -> ()) {
-        let activity = ActivityViewModel.getActivityFromUserDefault()
-        let error = ActivityViewModel.getErrorFromUserDefault()
-        completion(SimpleEntry(date: Date(), activity: activity, error: error))
-    }
-
-    @MainActor func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
-        self.initializeDependencies()
-        self.onGetTimeline()
-        
-        // Home screen was forced refresh, update the widget with user defaults only
-        if ActivityViewModel.getUnseenWidgetForceRefreshFromUserDefault() {
-            let activity = ActivityViewModel.getActivityFromUserDefault()
-            let error = ActivityViewModel.getErrorFromUserDefault()
-            viewModel.forceRefreshWidgetProcessed()
-            completion(buildTimeline(activity: activity, error: error))
-        } else {
-            Task {
-                await viewModel.fetchAndStoreRandomActivity()
-                completion(buildTimeline(activity: viewModel.activity, error: viewModel.error))
-            }
-        }
-    }
-    
-    @MainActor private func buildTimeline(activity: Activity?, error: ActivityError?) -> Timeline<SimpleEntry> {
-        let entries = [SimpleEntry(date: Date(), activity: activity, error: error)]
-        let refreshRate = Int(24 / Helper.getUserWidgetRefreshRatePerDay()!)
-        let nextUpdate = Calendar.current.date(byAdding: .hour, value: refreshRate, to: Date())!
-        return Timeline(entries: entries, policy: .after(nextUpdate))
-    }
-    
-    @MainActor private func onGetTimeline() {
-        if let athlete = StravaLoginViewModel.getAthleteFromUserDefault() {
-            Analytics.identify(athlete: athlete)
-        }
-        
-        Analytics.capture(event: .systemUpdateWidget)
-    }
-    
-    @MainActor private func initializeDependencies() {
-        // We don't really know where to do that for widgets, so we do it for every timeline refresh, as it's pretty rare
-        SentrySDK.start { options in
-            options.dsn = "https://2307db5e8e854158be765b26bce256ed@o4505126569246720.ingest.sentry.io/4505248857784320"
-            options.debug = false
-            options.environment = Config.env
-        }
-        
-        Analytics.initialize()
-    }
-}
-
-struct SimpleEntry: TimelineEntry {
-    let date: Date
-    let activity: Activity?
-    let error: ActivityError?
-    
-    init(date: Date, activity: Activity? = nil, error: ActivityError? = nil) {
-        self.date = date
-        self.activity = activity
-        self.error = error
-    }
-}
-
-struct MemoriesWidgetEntryView : View {
-    var entry: Provider.Entry
-
-    var body: some View {
-        MemoriesWidgetView(activity: entry.activity, error: entry.error)
-    }
-}
 
 struct MemoriesWidget: Widget {
     let kind: String = "MemoriesWidget"
     
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+        StaticConfiguration(kind: kind, provider: ClassicTimelineProvider()) { entry in
             MemoriesWidgetEntryView(entry: entry)
         }
         .contentMarginsDisabled()

--- a/MemoriesWidget/MemoriesWidgetBundle.swift
+++ b/MemoriesWidget/MemoriesWidgetBundle.swift
@@ -11,6 +11,14 @@ import SwiftUI
 @main
 struct MemoriesWidgetBundle: WidgetBundle {
     var body: some Widget {
-        MemoriesWidget()
+        widgets()
+    }
+    
+    func widgets() -> some Widget {
+        if #available(iOSApplicationExtension 17.0, *) {
+            return ConfigurableMemoriesWidget()
+        }
+        
+        return MemoriesWidget()
     }
 }

--- a/MemoriesWidget/MemoriesWidgetConfigurationIntent.swift
+++ b/MemoriesWidget/MemoriesWidgetConfigurationIntent.swift
@@ -1,5 +1,41 @@
 import AppIntents
 import WidgetKit
+import Activity
+
+@available(iOS 17, *)
+class ConfigurationTimelineProvider: AppIntentTimelineProvider {
+    typealias Entry = SimpleEntry
+    typealias Intent = MemoriesWidgetConfigurationIntent
+    
+    private let common = TimelineCommon()
+    private let viewModel = ActivityViewModel()
+    
+    func placeholder(in context: Context) -> SimpleEntry {
+        return SimpleEntry(date: Date())
+    }
+    
+    func snapshot(for configuration: MemoriesWidgetConfigurationIntent, in context: Context) async -> SimpleEntry {
+        let activity = ActivityViewModel.getActivityFromUserDefault()
+        let error = ActivityViewModel.getErrorFromUserDefault()
+        return SimpleEntry(date: Date(), activity: activity, error: error)
+    }
+    
+    func timeline(for configuration: MemoriesWidgetConfigurationIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        self.common.initializeDependencies()
+        await self.common.onGetTimeline()
+        
+        // Home screen was forced refresh, update the widget with user defaults only
+        if ActivityViewModel.getUnseenWidgetForceRefreshFromUserDefault() {
+            let activity = ActivityViewModel.getActivityFromUserDefault()
+            let error = ActivityViewModel.getErrorFromUserDefault()
+            viewModel.forceRefreshWidgetProcessed()
+            return self.common.buildTimeline(activity: activity, error: error)
+        } else {
+            await viewModel.fetchRandomActivity(persist: configuration.priority == .main)
+            return self.common.buildTimeline(activity: viewModel.activity, error: viewModel.error)
+        }
+    }
+}
 
 @available(iOS 17, *)
 struct MemoriesWidgetConfigurationIntent: WidgetConfigurationIntent {

--- a/MemoriesWidget/MemoriesWidgetConfigurationIntent.swift
+++ b/MemoriesWidget/MemoriesWidgetConfigurationIntent.swift
@@ -1,0 +1,32 @@
+import AppIntents
+import WidgetKit
+
+@available(iOS 17, *)
+struct MemoriesWidgetConfigurationIntent: WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Background Color"
+    static let description = IntentDescription("Change the background of the widget.")
+
+    @Parameter(title: "Priority", default: IntentWidgetPriority.unknown)
+    var priority: IntentWidgetPriority
+
+    init(
+        priority: IntentWidgetPriority
+    ) {
+        self.priority = priority
+    }
+
+    init() {}
+}
+
+@available(iOS 17, *)
+enum IntentWidgetPriority: String, AppEnum {
+    case unknown
+    case main
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Priority")
+
+    static let caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .unknown: DisplayRepresentation(title: "Unknown"),
+        .main: DisplayRepresentation(title: "Main")
+    ]
+}

--- a/MemoriesWidget/SimpleEntry.swift
+++ b/MemoriesWidget/SimpleEntry.swift
@@ -1,0 +1,31 @@
+//
+//  SimpleEntry.swift
+//  Memories
+//
+//  Created by Paul Nicolet on 14/11/2023.
+//
+
+import Foundation
+import WidgetKit
+import Activity
+import SwiftUI
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let activity: Activity?
+    let error: ActivityError?
+    
+    init(date: Date, activity: Activity? = nil, error: ActivityError? = nil) {
+        self.date = date
+        self.activity = activity
+        self.error = error
+    }
+}
+
+struct MemoriesWidgetEntryView : View {
+    var entry: SimpleEntry
+
+    var body: some View {
+        MemoriesWidgetView(activity: entry.activity, error: entry.error)
+    }
+}

--- a/MemoriesWidget/TimelineCommon.swift
+++ b/MemoriesWidget/TimelineCommon.swift
@@ -1,0 +1,39 @@
+//
+//  TimelineCommon.swift
+//  Memories
+//
+//  Created by Paul Nicolet on 14/11/2023.
+//
+
+import Foundation
+import Activity
+import WidgetKit
+import Sentry
+
+struct TimelineCommon {
+    public func buildTimeline(activity: Activity?, error: ActivityError?) -> Timeline<SimpleEntry> {
+        let entries = [SimpleEntry(date: Date(), activity: activity, error: error)]
+        let refreshRate = Int(24 / Helper.getUserWidgetRefreshRatePerDay()!)
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: refreshRate, to: Date())!
+        return Timeline(entries: entries, policy: .after(nextUpdate))
+    }
+    
+    @MainActor public func onGetTimeline() {
+        if let athlete = StravaLoginViewModel.getAthleteFromUserDefault() {
+            Analytics.identify(athlete: athlete)
+        }
+        
+        Analytics.capture(event: .systemUpdateWidget)
+    }
+    
+    public func initializeDependencies() {
+        // We don't really know where to do that for widgets, so we do it for every timeline refresh, as it's pretty rare
+        SentrySDK.start { options in
+            options.dsn = "https://2307db5e8e854158be765b26bce256ed@o4505126569246720.ingest.sentry.io/4505248857784320"
+            options.debug = false
+            options.environment = Config.env
+        }
+        
+        Analytics.initialize()
+    }
+}


### PR DESCRIPTION
Closes #6

When the widget is also added on macOS Sonoma desktop, there are conflicts between the iOS and macOS widget both writing to storage. Then when opening the app, you might end up having a refresh and being showed the macOS activity, which is weird.

I've checked and found no way to detect that the widget is running on a mac, all the indicators and flags and properties indicate that it's running on iPhone and iOS 17, which is wtf.

So I end up creating a widget that is configurable, and it's on the user to mark the iPhone widget as "main" and let the macOS one as secondary. Only the main widget will update the storage. It's quite overkill, but we don't expect many users to use the widget on macOS for now 😄